### PR TITLE
Use generator 0.1.1 2ed9b6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :development, :test do
   gem 'debug'
 end
 
-gem 'inferno_suite_generator', github: 'hl7au/inferno_suite_generator', ref: 'a5238f643c6f9231b677ff8d087015aecb46f64b'
+gem 'inferno_suite_generator', github: 'hl7au/inferno_suite_generator', ref: 'e66b9ba244560df63bc93172f729b91e6f0c21f8'
 # gem 'inferno_suite_generator', path: '../beda/os/inferno_suite_generator'
 gem 'pg', '~> 1.5'
 gem 'rubocop', '~> 1.63.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: https://github.com/hl7au/inferno_suite_generator.git
-  revision: a5238f643c6f9231b677ff8d087015aecb46f64b
-  ref: a5238f643c6f9231b677ff8d087015aecb46f64b
+  revision: e66b9ba244560df63bc93172f729b91e6f0c21f8
+  ref: e66b9ba244560df63bc93172f729b91e6f0c21f8
   specs:
-    inferno_suite_generator (1.0.0)
+    inferno_suite_generator (0.1.1)
       deep_merge (~> 1.2, >= 1.2.2)
-      inferno_core (>= 0.6.1)
+      inferno_core (>= 1.0.6)
       jsonpath (~> 1.1, >= 1.1.5)
 
 PATH

--- a/config.basic.json
+++ b/config.basic.json
@@ -259,6 +259,9 @@
       },
       "Parameters": {
         "skip": true
+      },
+      "Observation": {
+        "fixed_values_to_search": ["code"]
       }
     }
   }

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/allergy_intolerance/metadata.yml
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/allergy_intolerance/metadata.yml
@@ -151,4 +151,3 @@
 :id: smart_health_checks_v040_allergy_intolerance
 :file_name: allergy_intolerance_group.rb
 :delayed_references: []
-:ig_id: csiro.fhir.au.smartforms

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/encounter/metadata.yml
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/encounter/metadata.yml
@@ -168,4 +168,3 @@
 :id: smart_health_checks_v040_encounter
 :file_name: encounter_group.rb
 :delayed_references: []
-:ig_id: csiro.fhir.au.smartforms

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/immunization/metadata.yml
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/immunization/metadata.yml
@@ -193,4 +193,3 @@
 :id: smart_health_checks_v040_immunization
 :file_name: immunization_group.rb
 :delayed_references: []
-:ig_id: csiro.fhir.au.smartforms

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/medication_statement/medication_statement_patient_search_test.rb
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/medication_statement/medication_statement_patient_search_test.rb
@@ -51,9 +51,7 @@ requirement of Smart Health Checks v0.4.0.
           first_search: true,
           resource_type: 'MedicationStatement',
           search_param_names: ['patient'],
-          saves_delayed_references: true,
           possible_status_search: true,
-          includes: [{ 'parameter' => 'MedicationStatement:medication', 'target_resource' => '', 'paths' => '' }],
           test_reference_variants: true,
           test_post_search: true
         )

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/medication_statement/medication_statement_patient_status_search_test.rb
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/medication_statement/medication_statement_patient_status_search_test.rb
@@ -35,8 +35,7 @@ none are returned, the test is skipped.
       def self.properties
         @properties ||= InfernoSuiteGenerator::SearchTestProperties.new(
           resource_type: 'MedicationStatement',
-          search_param_names: %w[patient status],
-          includes: [{ 'parameter' => 'MedicationStatement:medication', 'target_resource' => '', 'paths' => '' }]
+          search_param_names: %w[patient status]
         )
       end
 

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/medication_statement/medication_statement_status_search_test.rb
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/medication_statement/medication_statement_status_search_test.rb
@@ -32,8 +32,7 @@ none are returned, the test is skipped.
       def self.properties
         @properties ||= InfernoSuiteGenerator::SearchTestProperties.new(
           resource_type: 'MedicationStatement',
-          search_param_names: ['status'],
-          includes: [{ 'parameter' => 'MedicationStatement:medication', 'target_resource' => '', 'paths' => '' }]
+          search_param_names: ['status']
         )
       end
 

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/medication_statement/metadata.yml
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/medication_statement/metadata.yml
@@ -206,8 +206,4 @@
   :file_name: medication_statement_fhir_path_json_patch_test.rb
 :id: smart_health_checks_v040_medication_statement
 :file_name: medication_statement_group.rb
-:delayed_references:
-- :path: medication[x]
-  :resources:
-  - Medication
-:ig_id: csiro.fhir.au.smartforms
+:delayed_references: []

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/metadata.yml
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/metadata.yml
@@ -142,92 +142,6 @@
     - RelatedPerson
     - Organization
   :delayed_references: []
-  :ig_id: csiro.fhir.au.smartforms
-- :name: SHCExtractBundle
-  :class_name: ShcextractbundleSequence
-  :version: v0.4.0
-  :reformatted_version: v040
-  :resource: Bundle
-  :profile_url: https://smartforms.csiro.au/ig/StructureDefinition/SHCExtractBundle
-  :profile_name: Smart Health Checks Extract Bundle
-  :profile_version: 0.4.0
-  :title: Extract Bundle
-  :short_description: Verify support for the server capabilities required by the Smart
-    Health Checks Extract Bundle.
-  :interactions: []
-  :operations: []
-  :searches: []
-  :search_definitions: {}
-  :include_params: []
-  :revincludes: []
-  :required_concepts: []
-  :must_supports:
-    :extensions: []
-    :slices:
-    - :slice_id: Bundle.entry:post
-      :slice_name: post
-      :path: entry
-      :discriminator:
-        :type: value
-        :values:
-        - :path: request.method
-          :value: POST
-    - :slice_id: Bundle.entry:patch
-      :slice_name: patch
-      :path: entry
-      :discriminator:
-        :type: value
-        :values:
-        - :path: request.method
-          :value: PATCH
-    :elements:
-    - :path: type
-      :fixed_value: transaction
-    - :path: timestamp
-    - :path: entry:post.fullUrl
-    - :path: entry:post.resource
-    - :path: entry:post.request
-    - :path: entry:post.request.method
-      :fixed_value: POST
-    - :path: entry:post.request.url
-    - :path: entry:patch.fullUrl
-    - :path: entry:patch.resource
-    - :path: entry:patch.request
-    - :path: entry:patch.request.method
-      :fixed_value: PATCH
-    - :path: entry:patch.request.url
-  :mandatory_elements:
-  - Bundle.type
-  - Bundle.timestamp
-  - Bundle.link.relation
-  - Bundle.link.url
-  - Bundle.entry
-  - Bundle.entry.request.method
-  - Bundle.entry.request.url
-  - Bundle.entry.response.status
-  - Bundle.entry.fullUrl
-  - Bundle.entry.resource
-  - Bundle.entry.request
-  :bindings:
-  - :type: code
-    :strength: required
-    :system: http://hl7.org/fhir/ValueSet/search-entry-mode
-    :path: entry.search.mode
-  - :type: code
-    :strength: required
-    :system: http://hl7.org/fhir/ValueSet/http-verb
-    :path: entry.request.method
-  - :type: code
-    :strength: required
-    :system: http://hl7.org/fhir/ValueSet/search-entry-mode
-    :path: entry.search.mode
-  - :type: code
-    :strength: required
-    :system: http://hl7.org/fhir/ValueSet/search-entry-mode
-    :path: entry.search.mode
-  :references: []
-  :delayed_references: []
-  :ig_id: csiro.fhir.au.smartforms
 - :name: SHCCondition
   :class_name: ShcconditionSequence
   :version: v0.4.0
@@ -409,7 +323,6 @@
     - RelatedPerson
     - Organization
   :delayed_references: []
-  :ig_id: csiro.fhir.au.smartforms
 - :name: SHCEncounter
   :class_name: ShcencounterSequence
   :version: v0.4.0
@@ -568,7 +481,6 @@
     :resource_types:
     - Encounter
   :delayed_references: []
-  :ig_id: csiro.fhir.au.smartforms
 - :name: SHCImmunization
   :class_name: ShcimmunizationSequence
   :version: v0.4.0
@@ -746,49 +658,6 @@
     :resource_types:
     - Organization
   :delayed_references: []
-  :ig_id: csiro.fhir.au.smartforms
-- :name: SHCMedication
-  :class_name: ShcmedicationSequence
-  :version: v0.4.0
-  :reformatted_version: v040
-  :resource: Medication
-  :profile_url: https://smartforms.csiro.au/ig/StructureDefinition/SHCMedication
-  :profile_name: Smart Health Checks Medication
-  :profile_version: 0.4.0
-  :title: Medication
-  :short_description: Verify support for the server capabilities required by the Smart
-    Health Checks Medication.
-  :interactions:
-  - :code: read
-    :expectation: SHALL
-  :operations: []
-  :searches: []
-  :search_definitions: {}
-  :include_params: []
-  :revincludes: []
-  :required_concepts: []
-  :must_supports:
-    :extensions: []
-    :slices: []
-    :elements:
-    - :path: id
-    - :path: code
-  :mandatory_elements:
-  - Medication.code
-  - Medication.ingredient.item[x]
-  :bindings:
-  - :type: code
-    :strength: required
-    :system: http://hl7.org/fhir/ValueSet/medication-status
-    :path: status
-  :references:
-  - :path: Medication.manufacturer
-    :profiles:
-    - http://hl7.org/fhir/StructureDefinition/Organization|4.0.1
-    :resource_types:
-    - Organization
-  :delayed_references: []
-  :ig_id: csiro.fhir.au.smartforms
 - :name: SHCMedicationStatement
   :class_name: ShcmedicationstatementSequence
   :version: v0.4.0
@@ -977,11 +846,7 @@
     - Patient
     - RelatedPerson
     - Organization
-  :delayed_references:
-  - :path: medication[x]
-    :resources:
-    - Medication
-  :ig_id: csiro.fhir.au.smartforms
+  :delayed_references: []
 - :name: SHCBloodPressure
   :class_name: ShcbloodpressureSequence
   :version: v0.4.0
@@ -1272,7 +1137,6 @@
     - MolecularSequence
     - Observation
   :delayed_references: []
-  :ig_id: csiro.fhir.au.smartforms
 - :name: SHCBodyHeight
   :class_name: ShcbodyheightSequence
   :version: v0.4.0
@@ -1526,7 +1390,6 @@
     - MolecularSequence
     - Observation
   :delayed_references: []
-  :ig_id: csiro.fhir.au.smartforms
 - :name: SHCBodyWeight
   :class_name: ShcbodyweightSequence
   :version: v0.4.0
@@ -1780,7 +1643,6 @@
     - MolecularSequence
     - Observation
   :delayed_references: []
-  :ig_id: csiro.fhir.au.smartforms
 - :name: SHCHeadCircumference
   :class_name: ShcheadcircumferenceSequence
   :version: v0.4.0
@@ -2041,7 +1903,6 @@
     - MolecularSequence
     - Observation
   :delayed_references: []
-  :ig_id: csiro.fhir.au.smartforms
 - :name: SHCHeartRate
   :class_name: ShcheartrateSequence
   :version: v0.4.0
@@ -2292,7 +2153,6 @@
     - MolecularSequence
     - Observation
   :delayed_references: []
-  :ig_id: csiro.fhir.au.smartforms
 - :name: SHCHeartRhythm
   :class_name: ShcheartrhythmSequence
   :version: v0.4.0
@@ -2501,7 +2361,6 @@
     - Observation
     - MolecularSequence
   :delayed_references: []
-  :ig_id: csiro.fhir.au.smartforms
 - :name: SHCPathologyResult
   :class_name: ShcpathologyresultSequence
   :version: v0.4.0
@@ -2764,7 +2623,6 @@
     - Observation
     - MolecularSequence
   :delayed_references: []
-  :ig_id: csiro.fhir.au.smartforms
 - :name: SHCSmokingStatus
   :class_name: ShcsmokingstatusSequence
   :version: v0.4.0
@@ -2964,7 +2822,6 @@
     - Observation
     - MolecularSequence
   :delayed_references: []
-  :ig_id: csiro.fhir.au.smartforms
 - :name: SHCWaistCircumference
   :class_name: ShcwaistcircumferenceSequence
   :version: v0.4.0
@@ -3218,291 +3075,6 @@
     - MolecularSequence
     - Observation
   :delayed_references: []
-  :ig_id: csiro.fhir.au.smartforms
-- :name: SHCPatchAllergyIntolerance
-  :class_name: ShcpatchallergyintoleranceSequence
-  :version: v0.4.0
-  :reformatted_version: v040
-  :resource: Parameters
-  :profile_url: https://smartforms.csiro.au/ig/StructureDefinition/SHCPatchAllergyIntolerance
-  :profile_name: Smart Health Checks Patch AllergyIntolerance
-  :profile_version: 0.4.0
-  :title: Patch AllergyIntolerance
-  :short_description: Verify support for the server capabilities required by the Smart
-    Health Checks Patch AllergyIntolerance.
-  :interactions: []
-  :operations: []
-  :searches: []
-  :search_definitions: {}
-  :include_params: &3 []
-  :revincludes: &4 []
-  :required_concepts:
-  - parameter.part.valueCodeableConcept
-  :must_supports:
-    :extensions: []
-    :slices:
-    - :slice_id: Parameters.parameter.part:type
-      :slice_name: type
-      :path: parameter.part
-      :discriminator:
-        :type: value
-        :values:
-        - :path: name
-          :value:
-    - :slice_id: Parameters.parameter.part:path
-      :slice_name: path
-      :path: parameter.part
-      :discriminator:
-        :type: value
-        :values:
-        - :path: name
-          :value:
-    - :slice_id: Parameters.parameter.part:value
-      :slice_name: value
-      :path: parameter.part
-      :discriminator:
-        :type: value
-        :values:
-        - :path: name
-          :value:
-    - :slice_id: Parameters.parameter.part:pathLabel
-      :slice_name: pathLabel
-      :path: parameter.part
-      :discriminator:
-        :type: value
-        :values:
-        - :path: name
-          :value:
-    :elements:
-    - :path: parameter
-    - :path: parameter.name
-    - :path: parameter.part:type.name
-    - :path: parameter.part:type.value[x]
-      :fixed_value: add
-    - :path: parameter.part:path.name
-    - :path: parameter.part:path.value[x]
-    - :path: parameter.part:name.name
-    - :path: parameter.part:name.value[x]
-    - :path: parameter.part:value.name
-    - :path: parameter.part:value.value[x]
-    - :path: parameter.part:value.value[x]:valueAnnotation.text
-    - :path: parameter.part:pathLabel.name
-    - :path: parameter.part:pathLabel.value[x]
-  :mandatory_elements:
-  - Parameters.parameter
-  - Parameters.parameter.name
-  - Parameters.parameter.part
-  - Parameters.parameter.part.name
-  - Parameters.parameter.part.value[x]
-  - Parameters.parameter.part.value[x].text
-  :bindings:
-  - :type: string
-    :strength: required
-    :system: https://smartforms.csiro.au/ig/ValueSet/SHCPatchAllergyIntoleranceElementPath
-    :path: parameter.part.value
-  - :type: string
-    :strength: required
-    :system: https://smartforms.csiro.au/ig/ValueSet/SHCPatchAllergyIntoleranceElementName
-    :path: parameter.part.value
-  :references:
-  - :path: Parameters.parameter.part.value[x].author[x]
-    :profiles:
-    - http://hl7.org/fhir/StructureDefinition/Practitioner|4.0.1
-    - http://hl7.org/fhir/StructureDefinition/Patient|4.0.1
-    - http://hl7.org/fhir/StructureDefinition/RelatedPerson|4.0.1
-    - http://hl7.org/fhir/StructureDefinition/Organization|4.0.1
-    :resource_types:
-    - Practitioner
-    - Patient
-    - RelatedPerson
-    - Organization
-  :delayed_references: []
-  :ig_id: csiro.fhir.au.smartforms
-- :name: SHCPatchCondition
-  :class_name: ShcpatchconditionSequence
-  :version: v0.4.0
-  :reformatted_version: v040
-  :resource: Parameters
-  :profile_url: https://smartforms.csiro.au/ig/StructureDefinition/SHCPatchCondition
-  :profile_name: Smart Health Checks Patch Condition
-  :profile_version: 0.4.0
-  :title: Patch Condition
-  :short_description: Verify support for the server capabilities required by the Smart
-    Health Checks Patch Condition.
-  :interactions: []
-  :operations: []
-  :searches: []
-  :search_definitions: {}
-  :include_params: *3
-  :revincludes: *4
-  :required_concepts:
-  - parameter.part.valueCodeableConcept
-  :must_supports:
-    :extensions: []
-    :slices:
-    - :slice_id: Parameters.parameter.part:type
-      :slice_name: type
-      :path: parameter.part
-      :discriminator:
-        :type: value
-        :values:
-        - :path: name
-          :value:
-    - :slice_id: Parameters.parameter.part:path
-      :slice_name: path
-      :path: parameter.part
-      :discriminator:
-        :type: value
-        :values:
-        - :path: name
-          :value:
-    - :slice_id: Parameters.parameter.part:value
-      :slice_name: value
-      :path: parameter.part
-      :discriminator:
-        :type: value
-        :values:
-        - :path: name
-          :value:
-    - :slice_id: Parameters.parameter.part:pathLabel
-      :slice_name: pathLabel
-      :path: parameter.part
-      :discriminator:
-        :type: value
-        :values:
-        - :path: name
-          :value:
-    :elements:
-    - :path: parameter
-    - :path: parameter.name
-    - :path: parameter.part:type.name
-    - :path: parameter.part:type.value[x]
-      :fixed_value: add
-    - :path: parameter.part:path.name
-    - :path: parameter.part:path.value[x]
-    - :path: parameter.part:name.name
-    - :path: parameter.part:name.value[x]
-    - :path: parameter.part:value.name
-    - :path: parameter.part:value.value[x]
-    - :path: parameter.part:pathLabel.name
-    - :path: parameter.part:pathLabel.value[x]
-  :mandatory_elements:
-  - Parameters.parameter
-  - Parameters.parameter.name
-  - Parameters.parameter.part
-  - Parameters.parameter.part.name
-  - Parameters.parameter.part.value[x]
-  :bindings:
-  - :type: string
-    :strength: required
-    :system: https://smartforms.csiro.au/ig/ValueSet/SHCPatchConditionElementPath
-    :path: parameter.part.value
-  - :type: string
-    :strength: required
-    :system: https://smartforms.csiro.au/ig/ValueSet/SHCPatchConditionElementName
-    :path: parameter.part.value
-  :references: []
-  :delayed_references: []
-  :ig_id: csiro.fhir.au.smartforms
-- :name: SHCPatchMedicationStatement
-  :class_name: ShcpatchmedicationstatementSequence
-  :version: v0.4.0
-  :reformatted_version: v040
-  :resource: Parameters
-  :profile_url: https://smartforms.csiro.au/ig/StructureDefinition/SHCPatchMedicationStatement
-  :profile_name: Smart Health Checks Patch MedicationStatement
-  :profile_version: 0.4.0
-  :title: Patch MedicationStatement
-  :short_description: Verify support for the server capabilities required by the Smart
-    Health Checks Patch MedicationStatement.
-  :interactions: []
-  :operations: []
-  :searches: []
-  :search_definitions: {}
-  :include_params: *3
-  :revincludes: *4
-  :required_concepts: []
-  :must_supports:
-    :extensions: []
-    :slices:
-    - :slice_id: Parameters.parameter.part:type
-      :slice_name: type
-      :path: parameter.part
-      :discriminator:
-        :type: value
-        :values:
-        - :path: name
-          :value:
-    - :slice_id: Parameters.parameter.part:path
-      :slice_name: path
-      :path: parameter.part
-      :discriminator:
-        :type: value
-        :values:
-        - :path: name
-          :value:
-    - :slice_id: Parameters.parameter.part:value
-      :slice_name: value
-      :path: parameter.part
-      :discriminator:
-        :type: value
-        :values:
-        - :path: name
-          :value:
-    - :slice_id: Parameters.parameter.part:pathLabel
-      :slice_name: pathLabel
-      :path: parameter.part
-      :discriminator:
-        :type: value
-        :values:
-        - :path: name
-          :value:
-    :elements:
-    - :path: parameter
-    - :path: parameter.name
-    - :path: parameter.part:type.name
-    - :path: parameter.part:type.value[x]
-      :fixed_value: add
-    - :path: parameter.part:path.name
-    - :path: parameter.part:path.value[x]
-    - :path: parameter.part:name.name
-    - :path: parameter.part:name.value[x]
-    - :path: parameter.part:value.name
-    - :path: parameter.part:value.value[x]
-    - :path: parameter.part:value.value[x]:valueDosage.text
-    - :path: parameter.part:value.value[x]:valueAnnotation.text
-    - :path: parameter.part:pathLabel.name
-    - :path: parameter.part:pathLabel.value[x]
-  :mandatory_elements:
-  - Parameters.parameter
-  - Parameters.parameter.name
-  - Parameters.parameter.part
-  - Parameters.parameter.part.name
-  - Parameters.parameter.part.value[x]
-  - Parameters.parameter.part.value[x].text
-  :bindings:
-  - :type: string
-    :strength: required
-    :system: https://smartforms.csiro.au/ig/ValueSet/SHCPatchMedicationStatementElementPath
-    :path: parameter.part.value
-  - :type: string
-    :strength: required
-    :system: https://smartforms.csiro.au/ig/ValueSet/SHCPatchMedicationStatementElementName
-    :path: parameter.part.value
-  :references:
-  - :path: Parameters.parameter.part.value[x].author[x]
-    :profiles:
-    - http://hl7.org/fhir/StructureDefinition/Practitioner|4.0.1
-    - http://hl7.org/fhir/StructureDefinition/Patient|4.0.1
-    - http://hl7.org/fhir/StructureDefinition/RelatedPerson|4.0.1
-    - http://hl7.org/fhir/StructureDefinition/Organization|4.0.1
-    :resource_types:
-    - Practitioner
-    - Patient
-    - RelatedPerson
-    - Organization
-  :delayed_references: []
-  :ig_id: csiro.fhir.au.smartforms
 - :name: SHCPatient
   :class_name: ShcpatientSequence
   :version: v0.4.0
@@ -3646,7 +3218,6 @@
     - Patient
     - RelatedPerson
   :delayed_references: []
-  :ig_id: csiro.fhir.au.smartforms
 - :name: SHCPractitioner
   :class_name: ShcpractitionerSequence
   :version: v0.4.0
@@ -3696,7 +3267,6 @@
     :resource_types:
     - Organization
   :delayed_references: []
-  :ig_id: csiro.fhir.au.smartforms
 - :name: SHCQuestionnaireResponse
   :class_name: ShcquestionnaireresponseSequence
   :version: v0.4.0
@@ -3907,4 +3477,3 @@
     - Device
     - Organization
   :delayed_references: []
-  :ig_id: csiro.fhir.au.smartforms

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/patient/metadata.yml
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/patient/metadata.yml
@@ -151,4 +151,3 @@
 :id: smart_health_checks_v040_patient
 :file_name: patient_group.rb
 :delayed_references: []
-:ig_id: csiro.fhir.au.smartforms

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/practitioner/metadata.yml
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/practitioner/metadata.yml
@@ -57,4 +57,3 @@
 :id: smart_health_checks_v040_practitioner
 :file_name: practitioner_group.rb
 :delayed_references: []
-:ig_id: csiro.fhir.au.smartforms

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/questionnaire_response/metadata.yml
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/questionnaire_response/metadata.yml
@@ -236,4 +236,3 @@
 :id: smart_health_checks_v040_questionnaire_response
 :file_name: questionnaire_response_group.rb
 :delayed_references: []
-:ig_id: csiro.fhir.au.smartforms

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_blood_pressure/metadata.yml
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_blood_pressure/metadata.yml
@@ -306,4 +306,3 @@
 :id: smart_health_checks_v040_shc_blood_pressure
 :file_name: shc_blood_pressure_group.rb
 :delayed_references: []
-:ig_id: csiro.fhir.au.smartforms

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_body_height/metadata.yml
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_body_height/metadata.yml
@@ -269,4 +269,3 @@
 :id: smart_health_checks_v040_shc_body_height
 :file_name: shc_body_height_group.rb
 :delayed_references: []
-:ig_id: csiro.fhir.au.smartforms

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_body_weight/metadata.yml
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_body_weight/metadata.yml
@@ -269,4 +269,3 @@
 :id: smart_health_checks_v040_shc_body_weight
 :file_name: shc_body_weight_group.rb
 :delayed_references: []
-:ig_id: csiro.fhir.au.smartforms

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_condition/metadata.yml
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_condition/metadata.yml
@@ -199,4 +199,3 @@
 :id: smart_health_checks_v040_shc_condition
 :file_name: shc_condition_group.rb
 :delayed_references: []
-:ig_id: csiro.fhir.au.smartforms

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_head_circumference/metadata.yml
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_head_circumference/metadata.yml
@@ -276,4 +276,3 @@
 :id: smart_health_checks_v040_shc_head_circumference
 :file_name: shc_head_circumference_group.rb
 :delayed_references: []
-:ig_id: csiro.fhir.au.smartforms

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_heart_rate/metadata.yml
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_heart_rate/metadata.yml
@@ -266,4 +266,3 @@
 :id: smart_health_checks_v040_shc_heart_rate
 :file_name: shc_heart_rate_group.rb
 :delayed_references: []
-:ig_id: csiro.fhir.au.smartforms

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_heart_rhythm/metadata.yml
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_heart_rhythm/metadata.yml
@@ -224,4 +224,3 @@
 :id: smart_health_checks_v040_shc_heart_rhythm
 :file_name: shc_heart_rhythm_group.rb
 :delayed_references: []
-:ig_id: csiro.fhir.au.smartforms

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_pathology_result/metadata.yml
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_pathology_result/metadata.yml
@@ -278,4 +278,3 @@
 :id: smart_health_checks_v040_shc_pathology_result
 :file_name: shc_pathology_result_group.rb
 :delayed_references: []
-:ig_id: csiro.fhir.au.smartforms

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_smoking_status/metadata.yml
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_smoking_status/metadata.yml
@@ -215,4 +215,3 @@
 :id: smart_health_checks_v040_shc_smoking_status
 :file_name: shc_smoking_status_group.rb
 :delayed_references: []
-:ig_id: csiro.fhir.au.smartforms

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_waist_circumference/metadata.yml
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_waist_circumference/metadata.yml
@@ -269,4 +269,3 @@
 :id: smart_health_checks_v040_shc_waist_circumference
 :file_name: shc_waist_circumference_group.rb
 :delayed_references: []
-:ig_id: csiro.fhir.au.smartforms

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/smart_health_checks_test_suite.rb
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/smart_health_checks_test_suite.rb
@@ -38,7 +38,7 @@ module SmartHealthChecksTestKit
         HL7® FHIR® resources are validated with the Java validator using
         https://tx.dev.hl7.org.au/fhir as the terminology server.
 
-        The test suite is generated using the [InfernoSuiteGenerator](https://github.com/hl7au/inferno_suite_generator) gem version 1.0.0.
+        The test suite is generated using the [InfernoSuiteGenerator](https://github.com/hl7au/inferno_suite_generator) gem version 0.1.1.
       )
       version VERSION
 


### PR DESCRIPTION
Updates the inferno_suite_generator gem to version 0.1.1 (commit e66b9ba) and regenerates the test suite.

### Changes

**Generator & dependencies**
- Updated inferno_suite_generator ref from a5238f6 to e66b9ba
- Bumped inferno_core minimum requirement from >= 0.6.1 to >= 1.0.6
  
**Config**
- Added fixed_values_to_search: ["code"] for Observation in config.basic.json to ensure Observation searches use the code parameter with fixed values

**Removed profiles**
The following profiles are no longer present in the current IG version and have been dropped from the generated suite:
- SHCExtractBundle
- SHCMedication
- SHCPatchAllergyIntolerance
- SHCPatchCondition
- SHCPatchMedicationStatement

**Metadata cleanup**
- Removed :ig_id field from all resource metadata.yml files — the new generator no longer emits this per-resource field