### PR TITLE
Update suite generator to fix the issue related to incorrect MS check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :development, :test do
   gem 'debug'
 end
 
-gem 'inferno_suite_generator', github: 'hl7au/inferno_suite_generator', ref: '8af39ac16687c07cd63c775c61389be0a598d542'
+gem 'inferno_suite_generator', github: 'hl7au/inferno_suite_generator', ref: '9a25b26afc144044807d16c259f2eecc804d82ec'
 # gem 'inferno_suite_generator', path: '../beda/os/inferno_suite_generator'
 gem 'pg', '~> 1.5'
 gem 'rubocop', '~> 1.63.2'

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :development, :test do
   gem 'debug'
 end
 
-gem 'inferno_suite_generator', github: 'hl7au/inferno_suite_generator', ref: 'e66b9ba244560df63bc93172f729b91e6f0c21f8'
+gem 'inferno_suite_generator', github: 'hl7au/inferno_suite_generator', ref: '8af39ac16687c07cd63c775c61389be0a598d542'
 # gem 'inferno_suite_generator', path: '../beda/os/inferno_suite_generator'
 gem 'pg', '~> 1.5'
 gem 'rubocop', '~> 1.63.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/hl7au/inferno_suite_generator.git
-  revision: e66b9ba244560df63bc93172f729b91e6f0c21f8
-  ref: e66b9ba244560df63bc93172f729b91e6f0c21f8
+  revision: 8af39ac16687c07cd63c775c61389be0a598d542
+  ref: 8af39ac16687c07cd63c775c61389be0a598d542
   specs:
     inferno_suite_generator (0.1.1)
       deep_merge (~> 1.2, >= 1.2.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/hl7au/inferno_suite_generator.git
-  revision: 8af39ac16687c07cd63c775c61389be0a598d542
-  ref: 8af39ac16687c07cd63c775c61389be0a598d542
+  revision: 9a25b26afc144044807d16c259f2eecc804d82ec
+  ref: 9a25b26afc144044807d16c259f2eecc804d82ec
   specs:
     inferno_suite_generator (0.1.1)
       deep_merge (~> 1.2, >= 1.2.2)

--- a/config.basic.json
+++ b/config.basic.json
@@ -241,7 +241,7 @@
         }
       },
       "https://smartforms.csiro.au/ig/StructureDefinition/SHCQuestionnaireResponse": {
-        "exclude_elements_from_must_support": ["identifier", "item.text", "item.answer", "item.answer.value[x]", "item.answer.item"] 
+        "exclude_elements_from_must_support": ["identifier", "item.text", "item.answer", "item.answer.value[x]", "item.answer.item"]
       }
     },
     "resources": {
@@ -249,7 +249,8 @@
         "fixed_values_to_search": ["category"]
       },
       "MedicationStatement": {
-        "resources_to_create_filter": "MedicationStatement.medicationCodeableConcept.exists()"
+        "resources_to_create_filter": "MedicationStatement.medicationCodeableConcept.exists()",
+        "create_resource_overrides": { "dateAsserted": "${DateTime.now}" }
       },
       "Medication": {
         "skip": true

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/allergy_intolerance/allergy_intolerance_create_test.rb
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/allergy_intolerance/allergy_intolerance_create_test.rb
@@ -43,6 +43,10 @@ module SmartHealthChecksTestKit
         nil
       end
 
+      def create_resource_overrides
+        {}
+      end
+
       run do
         perform_create_test
       end

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/immunization/immunization_create_test.rb
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/immunization/immunization_create_test.rb
@@ -43,6 +43,10 @@ module SmartHealthChecksTestKit
         nil
       end
 
+      def create_resource_overrides
+        {}
+      end
+
       run do
         perform_create_test
       end

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/medication_statement/medication_statement_create_test.rb
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/medication_statement/medication_statement_create_test.rb
@@ -44,6 +44,14 @@ module SmartHealthChecksTestKit
         'MedicationStatement.medicationCodeableConcept.exists()'
       end
 
+      def create_resource_overrides
+        {
+
+          'dateAsserted' => '${DateTime.now}'
+
+        }
+      end
+
       run do
         perform_create_test
       end

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/questionnaire_response/questionnaire_response_create_test.rb
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/questionnaire_response/questionnaire_response_create_test.rb
@@ -43,6 +43,10 @@ module SmartHealthChecksTestKit
         nil
       end
 
+      def create_resource_overrides
+        {}
+      end
+
       run do
         perform_create_test
       end

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_blood_pressure/shc_blood_pressure_create_test.rb
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_blood_pressure/shc_blood_pressure_create_test.rb
@@ -43,6 +43,10 @@ module SmartHealthChecksTestKit
         nil
       end
 
+      def create_resource_overrides
+        {}
+      end
+
       run do
         perform_create_test
       end

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_body_height/shc_body_height_create_test.rb
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_body_height/shc_body_height_create_test.rb
@@ -43,6 +43,10 @@ module SmartHealthChecksTestKit
         nil
       end
 
+      def create_resource_overrides
+        {}
+      end
+
       run do
         perform_create_test
       end

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_body_weight/shc_body_weight_create_test.rb
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_body_weight/shc_body_weight_create_test.rb
@@ -43,6 +43,10 @@ module SmartHealthChecksTestKit
         nil
       end
 
+      def create_resource_overrides
+        {}
+      end
+
       run do
         perform_create_test
       end

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_condition/shc_condition_create_test.rb
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_condition/shc_condition_create_test.rb
@@ -43,6 +43,10 @@ module SmartHealthChecksTestKit
         nil
       end
 
+      def create_resource_overrides
+        {}
+      end
+
       run do
         perform_create_test
       end

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_head_circumference/shc_head_circumference_create_test.rb
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_head_circumference/shc_head_circumference_create_test.rb
@@ -43,6 +43,10 @@ module SmartHealthChecksTestKit
         nil
       end
 
+      def create_resource_overrides
+        {}
+      end
+
       run do
         perform_create_test
       end

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_heart_rate/shc_heart_rate_create_test.rb
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_heart_rate/shc_heart_rate_create_test.rb
@@ -43,6 +43,10 @@ module SmartHealthChecksTestKit
         nil
       end
 
+      def create_resource_overrides
+        {}
+      end
+
       run do
         perform_create_test
       end

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_heart_rhythm/shc_heart_rhythm_create_test.rb
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_heart_rhythm/shc_heart_rhythm_create_test.rb
@@ -43,6 +43,10 @@ module SmartHealthChecksTestKit
         nil
       end
 
+      def create_resource_overrides
+        {}
+      end
+
       run do
         perform_create_test
       end

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_pathology_result/shc_pathology_result_create_test.rb
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_pathology_result/shc_pathology_result_create_test.rb
@@ -43,6 +43,10 @@ module SmartHealthChecksTestKit
         nil
       end
 
+      def create_resource_overrides
+        {}
+      end
+
       run do
         perform_create_test
       end

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_smoking_status/shc_smoking_status_create_test.rb
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_smoking_status/shc_smoking_status_create_test.rb
@@ -43,6 +43,10 @@ module SmartHealthChecksTestKit
         nil
       end
 
+      def create_resource_overrides
+        {}
+      end
+
       run do
         perform_create_test
       end

--- a/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_waist_circumference/shc_waist_circumference_create_test.rb
+++ b/lib/smart_health_checks_test_kit/generated/v0.4.0/shc_waist_circumference/shc_waist_circumference_create_test.rb
@@ -43,6 +43,10 @@ module SmartHealthChecksTestKit
         nil
       end
 
+      def create_resource_overrides
+        {}
+      end
+
       run do
         perform_create_test
       end


### PR DESCRIPTION
**Problem**

When validating must-support slice discriminators against FHIR resources that contain repeated array elements (e.g., Observation.component with both SystolicBP and DiastolicBP), the checker incorrectly reported elements as missing depending on their position in the array.

**Fix**

1. The fix is provided in the new version of the generator gem
2. Regenerated all *_create_test.rb files — each now exposes a create_resource_overrides method (introduced in the new generator version) to allow field-level overrides at test runtime

**References:**

1. SHC Suite issue: https://github.com/aehrc/smart-health-checks-inferno/issues/38
2. SHC Suite issue 2: https://github.com/aehrc/smart-health-checks-inferno/issues/44
3. Inferno suite generator issue: https://github.com/hl7au/inferno_suite_generator/issues/18
4. Inferno suite generator merged PR: https://github.com/hl7au/inferno_suite_generator/pull/17